### PR TITLE
Optimize `is_ident` with lookup table

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -1,13 +1,27 @@
-#[inline(never)]
+static IDENT_CHARS: [u32; 8] = {
+    let mut chars = [0u32; 8];
+    let mut i = 0;
+    while i < 256 {
+        let c = i as u8;
+        if c.is_ascii_digit()
+            || c.is_ascii_uppercase()
+            || c.is_ascii_lowercase()
+            || c == b'-'
+            || c == b'_'
+            || c == b':'
+            || c == b'+'
+            || c == b'/'
+        {
+            chars[i / 32] |= 1 << (i % 32);
+        }
+        i += 1;
+    }
+    chars
+};
+
 pub fn is_ident(c: u8) -> bool {
-    c.is_ascii_digit()
-        || c.is_ascii_uppercase()
-        || c.is_ascii_lowercase()
-        || c == b'-'
-        || c == b'_'
-        || c == b':'
-        || c == b'+'
-        || c == b'/'
+    let idx = c as usize;
+    (IDENT_CHARS[idx / 32] & (1 << (idx % 32))) != 0
 }
 
 #[inline(always)]


### PR DESCRIPTION
Optimizes the `is_ident` utility function by replacing multiple boolean comparisons with a compile-time generated lookup table.

```console
❯ cargo bench --bench tl
    Finished `bench` profile [optimized] target(s) in 0.07s
     Running benches/tl.rs (target/release/deps/tl-b12c3346556a1ba6)
tl                      time:   [1.2321 µs 1.2453 µs 1.2611 µs]
                        change: [-9.2911% -7.4838% -6.0314%] (p = 0.00 < 0.05)
                        Performance has improved.
```
