### PR TITLE
Fix fuzzer to reference `astral-tl`

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -12,6 +12,7 @@ cargo-fuzz = true
 libfuzzer-sys = "0.4"
 
 [dependencies.tl]
+package = "astral-tl"
 path = ".."
 features = ["__INTERNALS_DO_NOT_USE"] # we use it for fuzzing internals
 


### PR DESCRIPTION
Running the fuzzer would've caught the issue addressed in https://github.com/astral-sh/astral-tl/pull/16.